### PR TITLE
add colored icons to ZCA Bootstrap Colors page

### DIFF
--- a/YOUR_ADMIN/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/zca_bootstrap_colors.php
@@ -151,7 +151,10 @@ $cfg_group = $db->Execute("SELECT configuration_group_title
                     }
                     ?>
                   <td class="dataTableContent"><?php echo $item['configuration_title']; ?></td>
-                  <td class="dataTableContent"><?php echo htmlspecialchars($cfgValue, ENT_COMPAT, CHARSET, TRUE); ?></td>
+                  <td class="dataTableContent">
+                    <i class="fa fa-square fa-border" aria-hidden="true" style="font-size: 1.35em;margin-right:.5em;background-color:#ffffff;color:<?php echo htmlspecialchars($cfgValue, ENT_COMPAT, CHARSET, TRUE); ?>;"></i>
+                    <?php echo htmlspecialchars($cfgValue, ENT_COMPAT, CHARSET, TRUE); ?>
+                  </td>
                   <td class="dataTableContent text-right">
                       <?php
                       if ((isset($cInfo) && is_object($cInfo)) && ($item['configuration_id'] == $cInfo->configuration_id)) {


### PR DESCRIPTION
added to make it easier to find the setting you need to change for those less familiar with ZC naming of areas of the template and unfamiliar with working with hex codes for colors. A visual cue such as the colored icons will help.

![zca_bootstrap_colors_php](https://user-images.githubusercontent.com/1237035/72674506-1bad9c00-3a3d-11ea-8100-465969077a7c.png)
